### PR TITLE
fix: skip calculated values when saving

### DIFF
--- a/models/DataObject/Concrete/Dao.php
+++ b/models/DataObject/Concrete/Dao.php
@@ -195,6 +195,11 @@ class Dao extends Model\DataObject\AbstractObject\Dao
         $db = Db::get();
 
         foreach ($fieldDefinitions as $key => $fd) {
+            if ($fd instanceof DataObject\ClassDefinition\Data\CalculatedValue) {
+                $untouchable[] = $key;
+                continue;
+            }
+            
             if (method_exists($fd, 'getLazyLoading') && $fd->getLazyLoading()) {
                 if (!$this->model->isLazyKeyLoaded($key) || $fd instanceof DataObject\ClassDefinition\Data\ReverseManyToManyObjectRelation) {
                     //this is a relation subject to lazy loading - it has not been loaded


### PR DESCRIPTION
<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
-->
  
## Changes in this pull request  

If you have a `ComputedValue` instance which returns an array, you will no longer be able to save your object. This fix skips all calculated values.

Error without this fix:
```
Message: An exception occurred while executing 'INSERT INTO `object_query_1` (`Brand__id`, `Brand__type`, `SKU`, `EAN`, `Intrastat`, `WebSales`, `Status`, `Height__value`, `Height__unit`, `Width__value`, `Width__unit`, `Depth__value`, `Depth__unit`, `Weight__value`, `Weight__unit`, `UseUp`, `ReplacementProduct__id`, `ReplacementProduct__type`, `Images`, `ImageNotMatching`, `CADs`, `Supplier__id`, `Supplier__type`, `SupplierPartNumber`, `SupplierSeries`, `SupplierPrice`, `SupplierPriceCurrency`, `SupplierLeadTime`, `Manufacturer__id`, `Manufacturer__type`, `MPN`, `OriginCountry`, `PriceEUR`, `PriceGBP`, `PriceUSD`, `MarkupGroup`, `MarginEurGroup`, `Backorder`, `CustomerLeadTime`, `BackorderQTYmax`, `SeaBroadCampaign`, `BOM`, `Category__id`, `Category__type`, `AdditionalCat`, `NewCategory__id`, `NewCategory__type`, `NewAdditionalCat`, `0`, `1`, `Accessories`, `oo_id`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE `Brand__id` = ?, `Brand__type` = ?, `SKU` = ?, `EAN` = ?, `Intrastat` = ?, `WebSales` = ?, `Status` = ?, `Height__value` = ?, `Height__unit` = ?, `Width__value` = ?, `Width__unit` = ?, `Depth__value` = ?, `Depth__unit` = ?, `Weight__value` = ?, `Weight__unit` = ?, `UseUp` = ?, `ReplacementProduct__id` = ?, `ReplacementProduct__type` = ?, `Images` = ?, `ImageNotMatching` = ?, `CADs` = ?, `Supplier__id` = ?, `Supplier__type` = ?, `SupplierPartNumber` = ?, `SupplierSeries` = ?, `SupplierPrice` = ?, `SupplierPriceCurrency` = ?, `SupplierLeadTime` = ?, `Manufacturer__id` = ?, `Manufacturer__type` = ?, `MPN` = ?, `OriginCountry` = ?, `PriceEUR` = ?, `PriceGBP` = ?, `PriceUSD` = ?, `MarkupGroup` = ?, `MarginEurGroup` = ?, `Backorder` = ?, `CustomerLeadTime` = ?, `BackorderQTYmax` = ?, `SeaBroadCampaign` = ?, `BOM` = ?, `Category__id` = ?, `Category__type` = ?, `AdditionalCat` = ?, `NewCategory__id` = ?, `NewCategory__type` = ?, `NewAdditionalCat` = ?, `0` = ?, `1` = ?, `Accessories` = ?, `oo_id` = ?;' with params [1328, "object", "TestSKU published", "1234567891012", "1234567890", 1, "Approved", "10", "26", "20", "26", "30", "26", "40", "24", 1, 45562, "object", ",asset|39517,asset|39518,asset|39519,", 1, ",asset|27365,", 1302, "object", "supplierpartnumber23", "supplier serie", 1.23, "USD", 25, 1308, "object", "MPN 123", "NL", 15.16, 14.4, 17.59, "A", "1>2.5", 1, 5, 10, "Exclude", ",object|45428,object|46148,", 43627, "object", ",object|43628,object|43633,", 43798, "object", ",object|44727,object|44784,object|44704,", {"____pimcore_cache_item__":"object_63583"}, {"____pimcore_cache_item__":"object_63584"}, ",object|45101,object|45109,", 55532, 1328, "object", "TestSKU published", "1234567891012", "1234567890", 1, "Approved", "10", "26", "20", "26", "30", "26", "40", "24", 1, 45562, "object", ",asset|39517,asset|39518,asset|39519,", 1, ",asset|27365,", 1302, "object", "supplierpartnumber23", "supplier serie", 1.23, "USD", 25, 1308, "object", "MPN 123", "NL", 15.16, 14.4, 17.59, "A", "1>2.5", 1, 5, 10, "Exclude", ",object|45428,object|46148,", 43627, "object", ",object|43628,object|43633,", 43798, "object", ",object|44727,object|44784,object|44704,", {"____pimcore_cache_item__":"object_63583"}, {"____pimcore_cache_item__":"object_63584"}, ",object|45101,object|45109,", 55532]:

SQLSTATE[42S22]: Column not found: 1054 Unknown column '0' in 'field list'
Trace: 
#0 /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(169): Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception oc...', Object(Doctrine\DBAL\Driver\PDOException))
#1 /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(145): Doctrine\DBAL\DBALException::wrapException(Object(Doctrine\DBAL\Driver\PDOMySql\Driver), Object(Doctrine\DBAL\Driver\PDOException), 'An exception oc...')
#2 /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1063): Doctrine\DBAL\DBALException::driverExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDOMySql\Driver), Object(Doctrine\DBAL\Driver\PDOException), 'INSERT INTO `ob...', Array)
#3 /var/www/html/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php(111): Doctrine\DBAL\Connection->executeUpdate('INSERT INTO `ob...', Array, Array)
#4 /var/www/html/vendor/pimcore/pimcore/lib/Db/PimcoreExtensionsTrait.php(369): Pimcore\Db\Connection->executeUpdate('INSERT INTO `ob...', Array)
#5 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Concrete/Dao.php(380): Pimcore\Db\Connection->insertOrUpdate('object_query_1', Array)
#6 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Concrete.php(191): Pimcore\Model\DataObject\Concrete\Dao->update(true)
#7 /var/www/html/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php(662): Pimcore\Model\DataObject\Concrete->update(true, Array)
#8 /var/www/html/vendor/pimcore/pimcore/models/DataObject/Concrete.php(703): Pimcore\Model\DataObject\AbstractObject->save(Array)
#9 /var/www/html/vendor/pimcore/pimcore/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectController.php(1261): Pimcore\Model\DataObject\Concrete->save()
#10 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(151): Pimcore\Bundle\AdminBundle\Controller\Admin\DataObject\DataObjectController->saveAction(Object(Symfony\Component\HttpFoundation\Request))
#11 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#12 /var/www/html/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(200): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#13 /var/www/html/web/index.php(42): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#14 {main}
```